### PR TITLE
Added token refresh mechanism

### DIFF
--- a/03_customize-image.yaml
+++ b/03_customize-image.yaml
@@ -5,6 +5,11 @@
   become: False
 
   tasks:
+    - name: Check if image exists already
+      ansible.builtin.import_role:
+        name: image_builder
+        tasks_from: check-images-exist
+
     - name: Run customization tasks
       ansible.builtin.import_role:
         name: image_builder

--- a/04_upload-to-rhosp.yaml
+++ b/04_upload-to-rhosp.yaml
@@ -5,6 +5,11 @@
   become: False
 
   tasks:
+    - name: Check if image exists already
+      ansible.builtin.import_role:
+        name: image_builder
+        tasks_from: check-images-exist
+
     - name: Get refresh token
       ansible.builtin.import_role:
         name: image_builder
@@ -21,15 +26,6 @@
         tasks_from: verify-compose-finished
 
     - name: Upload images to rhosp
-      tags:
-        - upload
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: upload-to-rhosp
-
-    - name: Delete older image versions
-      tags:
-        - delete
-      ansible.builtin.import_role:
-        name: image_builder
-        tasks_from: delete-images

--- a/group_vars/all/image_definitions.yaml
+++ b/group_vars/all/image_definitions.yaml
@@ -1,5 +1,5 @@
 # Image definitions
-release_id: "rel-20240604v3"
+release_id: "rel-20240607v1"
 storage_dir: /mnt/persist/images
 
 filesystems:

--- a/lifecycle-images.yaml
+++ b/lifecycle-images.yaml
@@ -20,10 +20,6 @@
         name: image_builder
         tasks_from: request-image-creation
 
-    - name: Wait at least five minutes before checking
-      ansible.builtin.pause:
-        minutes: 5
-
     - name: Verify composes finished
       ansible.builtin.import_role:
         name: image_builder

--- a/roles/image_builder/defaults/main.yaml
+++ b/roles/image_builder/defaults/main.yaml
@@ -6,3 +6,12 @@ api_endpoint: https://console.redhat.com/api/image-builder/v1
 
 # Where to copy the images when downloading and customizing
 storage_dir: /tmp
+
+# How many times to check the status of image builds
+compose_check_retries: 10
+
+# For how long to wait between each image build status check
+compose_check_wait_secs: 60
+
+# How many loops of `compose_check_retries` to do, while renewing token in between loops (if expired)
+compose_check_max_loops: 3

--- a/roles/image_builder/tasks/customize-images.yaml
+++ b/roles/image_builder/tasks/customize-images.yaml
@@ -1,17 +1,16 @@
 - name: Run virt-customize
   ansible.builtin.shell: >
-    virt-customize -a {{ file_name }}
+    virt-customize -a {{ item.invocation.module_args.path }}
     --timezone Europe/Berlin
-  loop: "{{ images }}"
+  loop: "{{ filecheck.results }}"
   loop_control:
-    label: "{{ file_name }}"
+    label: "{{ item.invocation.module_args.path }}"
   async: 1200
   poll: 0
   register: customize
-  vars:
-    file_name: "{{ storage_dir | default('.') }}/{{ item.name }}-{{ release_id }}.qcow2"
   environment:
     LIBGUESTFS_BACKEND: direct
+  when: item.stat.exists
 
 - name: Confirm image customization finished
   ansible.builtin.async_status:
@@ -22,6 +21,4 @@
   delay: 60
   loop: "{{ customize.results }}"
   loop_control:
-    label: "{{ file_name }}"
-  vars:
-    file_name: "{{ storage_dir | default('.') }}/{{ item.item.name }}-{{ release_id }}.qcow2"
+    label: "{{ item.item.invocation.module_args.path }}"

--- a/roles/image_builder/tasks/customize-images.yaml
+++ b/roles/image_builder/tasks/customize-images.yaml
@@ -22,3 +22,4 @@
   loop: "{{ customize.results }}"
   loop_control:
     label: "{{ item.item.invocation.module_args.path }}"
+  when: item.changed

--- a/roles/image_builder/tasks/download-images.yaml
+++ b/roles/image_builder/tasks/download-images.yaml
@@ -1,4 +1,4 @@
-- name: Start images download
+- name: Start image download
   ansible.builtin.get_url:
     url: "{{ image_url }}"
     dest: "{{ image_path }}"
@@ -6,7 +6,10 @@
   loop: "{{ compose_status_request.results }}"
   loop_control:
     label: "{{ image_path | default('N/A') }}"
-  when: item.json is defined
+  when:
+    - item.json is defined
+    - item.json.image_status.status == "success"
+    - item.json.image_status.upload_status.status == "success"
   vars:
     image_url: "{{ item.json.image_status.upload_status.options.url }}"
     image_path: "{{ storage_dir | default('.') }}/{{ item.json.request.image_name }}-{{ release_id }}.qcow2"

--- a/roles/image_builder/tasks/upload-to-rhosp.yaml
+++ b/roles/image_builder/tasks/upload-to-rhosp.yaml
@@ -1,13 +1,16 @@
 - name: Upload images to rhosp
   openstack.cloud.image:
-    name: "{{ item.name }}"
-    id: "{{ (compose_status_request.results | selectattr('json.request.image_name', 'match', item.name) | map(attribute='item.json.id') | first) | default(omit) }}"
-    container_format: "{{ item.disk_format | default('bare') }}"
-    disk_format: "{{ item.disk_format | default('qcow2') }}"
-    state: "{{ item.state | default('present') }}"
-    filename: "{{ storage_dir | default('.') }}/{{ item.name }}-{{ item.release_id }}.qcow2"
-    tags: "{{ (item.tags | default([])) + [item.release_id] | default(omit) }}"
-    properties: "{{ item.properties | default(omit) }}"
-  loop: "{{ images }}"
+    name: "{{ image.name }}"
+    id: "{{ (compose_status_request.results | selectattr('json.request.image_name', 'match', image.name) | map(attribute='item.json.id') | first) | default(omit) }}"
+    container_format: "{{ image.container_format | default('bare') }}"
+    disk_format: "{{ image.disk_format | default('qcow2') }}"
+    state: "{{ image.state | default('present') }}"
+    filename: "{{ item.invocation.module_args.path }}"
+    tags: "{{ (image.tags | default([])) + [image.release_id] | default(omit) }}"
+    properties: "{{ image.properties | default(omit) }}"
+  loop: "{{ filecheck.results }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ image.name }}"
+  when: item.stat.exists
+  vars:
+    image: "{{ item.item }}"

--- a/roles/image_builder/tasks/verify-compose-finished.yaml
+++ b/roles/image_builder/tasks/verify-compose-finished.yaml
@@ -1,21 +1,45 @@
-- name: Verify compose request is finished
-  ansible.builtin.uri:
-    url: "{{ api_endpoint }}/composes/{{ item.json.id }}"
-    method: GET
-    headers:
-      Authorization: Bearer {{ refresh_token.json.access_token }}
-    status_code: 200
-  loop: "{{ compose_request.results | default([]) }}"
-  loop_control:
-    label: "{{  image_name }}: compose_status: {{ compose_status }}, upload_status: {{ upload_status }}"
-  vars:
-    image_name: "{{ item.invocation.module_args.body.image_name | default('N/A') }}"
-    compose_status: "{{ compose_status_request.json.image_status.status | default(False) }}"
-    upload_status: "{{ compose_status_request.json.image_status.upload_status.status | default(False) }}"
-  register: compose_status_request
-  when: item.json is defined
-  until:
-    - compose_status != "building"
-    - upload_status == "success"
-  retries: 20
-  delay: 60
+- block:
+    - name: Set retry counter
+      ansible.builtin.set_fact:
+        this_retry: "{{ this_retry | default(0) | int + 1 }}"
+
+    - name: Verify compose request is finished
+      ansible.builtin.uri:
+        url: "{{ api_endpoint }}/composes/{{ item.json.id }}"
+        method: GET
+        headers:
+          Authorization: Bearer {{ refresh_token.json.access_token }}
+        status_code: 200
+      loop: "{{ compose_request.results | default([]) }}"
+      loop_control:
+        label: "{{  image_name }}: compose_status: {{ compose_status }}, upload_status: {{ upload_status }}"
+      vars:
+        image_name: "{{ item.invocation.module_args.body.image_name | default('NoName') }}"
+        compose_status: "{{ compose_status_request.json.image_status.status | default(False) }}"
+        upload_status: "{{ compose_status_request.json.image_status.upload_status.status | default(False) }}"
+      register: compose_status_request
+      when:
+        - item.json is defined
+        - not compose_status_request.failed | default(False)
+      until: compose_status != "building"
+      retries: "{{ compose_check_retries }}"
+      delay: "{{ compose_check_wait_secs }}"
+
+  rescue:
+    - name: Fail if max attempts tried
+      ansible.builtin.fail:
+        msg: "Exhausted {{ compose_check_max_loops }} attempts when checking compose request status"
+      when: this_retry == compose_check_max_loops
+
+    - name: Renew token
+      ansible.builtin.include_tasks: ./get-refresh-token.yaml
+      when:  401 in compose_status_request.results | map(attribute='status', default='nostatus') | unique
+
+    - name: Unset compose_status_request.failed
+      set_fact:
+        compose_status_request:
+          failed: False
+      when: compose_status_request.failed
+
+    - name: Retry verify composes finished
+      ansible.builtin.include_tasks: ./verify-compose-finished.yaml

--- a/roles/image_builder/tasks/verify-compose-finished.yaml
+++ b/roles/image_builder/tasks/verify-compose-finished.yaml
@@ -21,7 +21,9 @@
       when:
         - item.json is defined
         - not compose_status_request.failed | default(False)
-      until: compose_status != "building"
+      until:
+        - compose_status != "building"
+        - compose_status != "pending"
       retries: "{{ compose_check_retries }}"
       delay: "{{ compose_check_wait_secs }}"
 


### PR DESCRIPTION
When checking for the status of one or more compose requests, it is possible that the token will expire before any of the requests finishes, as the refresh token is only valid for 15 minutes.

To overcome this limitation, a couple of tasks were added:
 - Compose check loops include less retries by default
 - When the loop of the first image fails, the loop is interrupted
 - When a 401 is detected as reason for failure, token is renewed
 - Loops are retried for (customizable) number of times

Additionally, image builder failures are now properly handled (skipped) in download and subsequent tasks.

Fixes #2 and #9 