### PR TITLE
Making offline customizations optional

### DIFF
--- a/group_vars/all/image_definitions.yaml
+++ b/group_vars/all/image_definitions.yaml
@@ -1,5 +1,5 @@
 # Image definitions
-release_id: "rel-20240617v1"
+release_id: "rel-20240617v2"
 storage_dir: /mnt/persist/images
 
 filesystems:
@@ -72,6 +72,7 @@ images:
       - lamp
 
   - name: rhel-8-base-ib
+    offline_customization: 'sed -i "s/^#\s\{0,\}\(PermitRootLogin\).*/\1 yes/" /etc/ssh/sshd_config'
     compose:
       distribution: rhel-8
       image_description: "RHEL 8.latest - {{ release_id }}"

--- a/roles/image_builder/tasks/customize-images.yaml
+++ b/roles/image_builder/tasks/customize-images.yaml
@@ -1,7 +1,7 @@
 - name: Run virt-customize
   ansible.builtin.shell: >
     virt-customize -a {{ item.invocation.module_args.path }}
-    --timezone Europe/Berlin
+    --run-command '{{ item.item.offline_customization }}'
   loop: "{{ filecheck.results }}"
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
@@ -10,7 +10,9 @@
   register: customize
   environment:
     LIBGUESTFS_BACKEND: direct
-  when: item.stat.exists
+  when:
+    - item.stat.exists
+    - item.item.offline_customization is defined | default(False)
 
 - name: Confirm image customization finished
   ansible.builtin.async_status:


### PR DESCRIPTION
Changing default behavior of offline customizations to False.

Offline customizations will only run with a command is explicitly added to the image definition. This way, an offline customization can run only on the images where required.

Updated documentation with important notes.

Fixes #10 