### PR TITLE
Make release_id optional

### DIFF
--- a/roles/image_builder/tasks/check-images-exist.yaml
+++ b/roles/image_builder/tasks/check-images-exist.yaml
@@ -1,10 +1,17 @@
 ---
+- name: Set fact with release_str if release_id is set
+  ansible.builtin.set_fact:
+    release_str: "-{{ release_id }}"
+  when: release_id is defined
+
 - name: Check if image exists
   ansible.builtin.stat:
-    path: "{{ storage_dir | default('.') }}/{{ item.name }}-{{ release_id }}.qcow2"
+    path: "{{ path }}"
   loop: "{{ images }}"
   loop_control:
-    label: "{{ item.name }}"
+    label: "{{ path }}"
+  vars:
+    path: "{{ storage_dir | default('.') }}/{{ item.name }}{{ release_str | default('') }}.qcow2"
   register: filecheck
 
 - name: Show file status

--- a/roles/image_builder/tasks/delete-images.yaml
+++ b/roles/image_builder/tasks/delete-images.yaml
@@ -13,7 +13,8 @@
     name: "{{ id }}"
     state: absent
   vars:
-    tags_release: "{{ item.0.item.tags | default([]) + [release_id] }}"
+    release_list: "{{ [ release_id | default([]) ] | flatten }}"
+    tags_release: "{{ item.0.item.tags | default([]) + release_list }}"
     tags_current: "{{ item.1.tags }}"
     id: "{{ item.1.id }}"
   when: tags_release | sort != tags_current | sort

--- a/roles/image_builder/tasks/download-images.yaml
+++ b/roles/image_builder/tasks/download-images.yaml
@@ -1,4 +1,9 @@
 ---
+- name: Set fact with release_str if release_id is set
+  ansible.builtin.set_fact:
+    release_str: "-{{ release_id }}"
+  when: release_id is defined
+
 - name: Start image download
   ansible.builtin.get_url:
     url: "{{ image_url }}"
@@ -13,7 +18,7 @@
     - item.json.image_status.upload_status.status == "success"
   vars:
     image_url: "{{ item.json.image_status.upload_status.options.url }}"
-    image_path: "{{ storage_dir | default('.') }}/{{ item.json.request.image_name }}-{{ release_id }}.qcow2"
+    image_path: "{{ storage_dir | default('.') }}/{{ item.json.request.image_name }}{{ release_str | default('') }}.qcow2"
   async: 600
   poll: 0
   register: download

--- a/roles/image_builder/tasks/get-composes.yaml
+++ b/roles/image_builder/tasks/get-composes.yaml
@@ -25,7 +25,7 @@
     - item[1].image_name is defined
     - item[1].image_name == item[0].name
     - item[1].request.image_description | default(false) == item[0].compose.image_description | default(false)
-  set_fact:
+  ansible.builtin.set_fact:
     composeids: "{{ composeids|default([]) + [ thisitem ] }}"
 
 - name: Set fact with compose_request

--- a/roles/image_builder/tasks/upload-to-rhosp.yaml
+++ b/roles/image_builder/tasks/upload-to-rhosp.yaml
@@ -9,7 +9,7 @@
     disk_format: "{{ image.disk_format | default('qcow2') }}"
     state: "{{ image.state | default('present') }}"
     filename: "{{ item.invocation.module_args.path }}"
-    tags: "{{ (image.tags | default([])) + [release_id] | default(omit) }}"
+    tags: "{{ image_tags + release_list }}"
     properties: "{{ image.properties | default(omit) }}"
   loop: "{{ filecheck.results }}"
   loop_control:
@@ -17,3 +17,5 @@
   when: item.stat.exists
   vars:
     image: "{{ item.item }}"
+    image_tags: "{{ image.tags | default([]) }}"
+    release_list: "{{ [ release_id | default([]) ] | flatten }}"

--- a/roles/image_builder/tasks/verify-compose-finished.yaml
+++ b/roles/image_builder/tasks/verify-compose-finished.yaml
@@ -22,6 +22,7 @@
       when:
         - item.json is defined
         - not compose_status_request.failed | default(false)
+        - not compose_status_request.skipped | default(false)
       until:
         - compose_status != "building"
         - compose_status != "pending"


### PR DESCRIPTION
This change makes usage of `release_id` optional. When defined in yaml, release_id is used as part of the downloaded file names (eg: `rhel-8.4-hardened-ib-2024-11-12.qcow2`). If the image is uploaded to RHOSP, a tag is added with the release_id as well.

When undefined, the name of the file is simply the name of the image (eg: `rhel-8.4-hardened-ib.qcow2`). Without a release_id to identify the files, if persistent storage is used, the image is not rotated.