### PR TITLE
Added extensions based on image type

### DIFF
--- a/roles/image_builder/defaults/main.yaml
+++ b/roles/image_builder/defaults/main.yaml
@@ -10,7 +10,7 @@ sso_endpoint: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid
 api_endpoint: https://console.redhat.com/api/image-builder/v1
 
 # Where to copy the images when downloading and customizing
-#storage_dir: .
+storage_dir: .
 
 # How many times to check the status of image builds
 compose_check_retries: 15
@@ -20,3 +20,14 @@ compose_check_wait_secs: 60
 
 # How many loops of `compose_check_retries` to do, while renewing token in between loops (if expired)
 compose_check_max_loops: 5
+
+# Map image types to file extensions
+image_type_to_extension:
+  guest-image: qcow2
+  edge-commit: tar
+  rhel-edge-commit: tar
+  edge-installer: iso
+  rhel-edge-installer: iso
+  image-installer: iso
+  vsphere: vmdk
+  vsphere-ova: ova

--- a/roles/image_builder/tasks/check-images-exist.yaml
+++ b/roles/image_builder/tasks/check-images-exist.yaml
@@ -11,13 +11,15 @@
   loop_control:
     label: "{{ path }}"
   vars:
-    path: "{{ storage_dir | default('.') }}/{{ item.name }}{{ release_str | default('') }}.qcow2"
+    file_name: "{{ item.name }}{{ release_str | default('') }}"
+    file_extension: "{{ image_type_to_extension[item.compose.image_type] | default(item.compose.image_type) }}"
+    path: "{{ storage_dir }}/{{ file_name }}.{{ file_extension }}"
   register: filecheck
 
 - name: Show file status
   loop: "{{ filecheck.results }}"
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
-  when: not item.stat.exists
+  #when: not item.stat.exists
   ansible.builtin.debug:
     msg: "{{ item.stat }}"

--- a/roles/image_builder/tasks/check-images-exist.yaml
+++ b/roles/image_builder/tasks/check-images-exist.yaml
@@ -20,6 +20,5 @@
   loop: "{{ filecheck.results }}"
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
-  #when: not item.stat.exists
   ansible.builtin.debug:
     msg: "{{ item.stat }}"

--- a/roles/image_builder/tasks/download-images.yaml
+++ b/roles/image_builder/tasks/download-images.yaml
@@ -7,18 +7,21 @@
 - name: Start image download
   ansible.builtin.get_url:
     url: "{{ image_url }}"
-    dest: "{{ image_path }}"
+    dest: "{{ path }}"
     mode: "0644"
   loop: "{{ compose_status_request.results }}"
   loop_control:
-    label: "{{ image_path | default('N/A') }}"
+    label: "{{ path | default('N/A') }}"
   when:
     - item.json is defined
     - item.json.image_status.status == "success"
     - item.json.image_status.upload_status.status == "success"
   vars:
     image_url: "{{ item.json.image_status.upload_status.options.url }}"
-    image_path: "{{ storage_dir | default('.') }}/{{ item.json.request.image_name }}{{ release_str | default('') }}.qcow2"
+    requested_type: "{{ item.json.request.image_requests[0].image_type }}"
+    file_name: "{{ item.json.request.image_name }}{{ release_str | default('') }}"
+    file_extension: "{{ image_type_to_extension[requested_type] | default(requested_type) }}"
+    path: "{{ storage_dir }}/{{ file_name }}.{{ file_extension }}"
   async: 600
   poll: 0
   register: download


### PR DESCRIPTION
The new default map of image types, `image_type_to_extension`, is used to translate the requested image type into the actual extension when checking and downloading an image.
Fixes #50.