### PR TITLE
Refactored data structure to align with API

### DIFF
--- a/create-and-download.yaml
+++ b/create-and-download.yaml
@@ -6,26 +6,31 @@
 
   tasks:
     - name: Check if image exists already
+      tags: filecheck
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: check-images-exist
 
     - name: Get refresh token
+      tags: token
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: get-refresh-token
 
     - name: Request creation of images
+      tags: request
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: request-image-creation
 
     - name: Verify composes finished
+      tags: verify
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: verify-compose-finished
 
     - name: Download images
+      tags: download
       ansible.builtin.import_role:
         name: image_builder
         tasks_from: download-images

--- a/examples/main.yaml
+++ b/examples/main.yaml
@@ -50,110 +50,104 @@ packages:
 images:
   # Minimal image definition
   - name: rhel-9-base-ib
-    compose:
-      distribution: rhel-9
-      image_description: Basic image based on RHEL 9.latest with no customizations
+    distribution: rhel-9
 
-  # Image based on an EUS distribution with hardening cusotmizations
+  # Same as above, but instead of preparing image for download, share with
+  # aws account
+  - name: rhel-9-base-aws-ib
+    distribution: rhel-9
+    requests:
+      image_type: aws
+      upload_request:
+        type: aws
+        options:
+          share_with_sources:
+            - "123456"
+
+  # Image with a custom size and in vmdk format for vSphere
+  - name: rhel-8-vsphere-ib
+    distribution: rhel-8
+    requests:
+      image_type: vsphere
+      size: 53687091200
+
+  # Image that uses an EUS distribution and ARM architecture
+  - name: rhel-9.2-arm-ib
+    description: RHEL 9.2 for ARM
+    distribution: rhel-92
+    requests:
+      architecture: aarch64
+
+  # Image that uses predefined list of filesystems, an EUS distribution
+  # and multiple hardening customizations
   - name: rhel-8.4-hardened-ib
-    compose:
-      distribution: rhel-84
-      image_description: Hardened RHEL 8.4 image with OSCAP profile enabled
-      customizations:
-        filesystem: "{{ filesystems.base }}"
-        packages: "{{ packages.base }}"
-        fips:
-          enabled: true
-        firewall:
-          services:
-            enabled:
-              - ssh
-        kernel:
-          append: "audit_backlog_limit=8192 audit=1 net.naming-scheme=rhel-8.4"
-        openscap:
-          profile_id: xccdf_org.ssgproject.content_profile_cis
+    description: Hardened RHEL 8.4 image with OSCAP profile enabled
+    distribution: rhel-84
+    customizations:
+      filesystem: "{{ filesystems.base }}"
+      packages: "{{ packages.base }}"
+      locale:
+        keyboard: gb
+        languages:
+          - en_GB.UTF-8
+      fips:
+        enabled: true
+      firewall:
         services:
           enabled:
-            - crond
-            - firewalld
-            - systemd-journald
-            - rsyslog
-            - auditd
-          masked:
-            - nfs-server
-            - rpcbind
-            - autofs
-            - bluetooth
-            - nftables
+            - ssh
+      kernel:
+        append: "audit_backlog_limit=8192 audit=1 net.naming-scheme=rhel-8.4"
+      openscap:
+        profile_id: xccdf_org.ssgproject.content_profile_cis
+      services:
+        enabled:
+          - crond
+          - firewalld
+          - systemd-journald
+          - rsyslog
+          - auditd
+        masked:
+          - nfs-server
+          - rpcbind
+          - autofs
+          - bluetooth
+          - nftables
 
-  # Base image that customizes the locale variables
-  - name: rhel-8-custom-locale-ib
-    compose:
-      distribution: rhel-8
-      image_description: RHEL 8.latest
-      customizations:
-        locale:
-          keyboard: gb
-          languages:
-            - en_GB.UTF-8
-
-  # RHEL 9 image with a LAMP configuration that uses:
-  # - Predefined filesystems and packages
-  # - Tags when uploading the image to RHOSP
+  # A legacy image with LAMP configuration that uses predefined filesystems and
+  # packages. Tags are only used when uploading to RHOSP.
   - name: rhel-9-lamp-ib
     tags:
       - lamp
-    compose:
-      distribution: rhel-9
-      image_description: LAMP on RHEL 9.latest
-      customizations:
-        filesystem: "{{ filesystems.base + filesystems.lamp }}"
-        packages: "{{ packages.base + packages.lamp }}"
-        files:
-          - path: /etc/sudoers.d/dbas
-            mode: "0600"
-            user: root
-            group: root
-            data: |
-              # Sudo rules for database administrators
-              %dbas ALL= /usr/bin/systemctl start mysqld.service
-              %dbas ALL= /usr/bin/systemctl stop mysqld.service
-              %dbas ALL= /usr/bin/systemctl restart mysqld.service
-              %dbas ALL= /usr/bin/systemctl reload mysqld.service
-        firewall:
-          ports:
-            - 8080:tcp
-          services:
-            enabled:
-              - ssh
-              - http
-              - https
-        groups:
-          - name: dbas
-            gid: 1002
+    distribution: rhel-9
+    description: LAMP on RHEL 9.latest
+    customizations:
+      filesystem: "{{ filesystems.base + filesystems.lamp }}"
+      packages: "{{ packages.base + packages.lamp }}"
+      files:
+        - path: /etc/sudoers.d/dbas
+          mode: "0600"
+          user: root
+          group: root
+          data: |
+            # Sudo rules for database administrators
+            %dbas ALL= /usr/bin/systemctl start mysqld.service
+            %dbas ALL= /usr/bin/systemctl stop mysqld.service
+            %dbas ALL= /usr/bin/systemctl restart mysqld.service
+            %dbas ALL= /usr/bin/systemctl reload mysqld.service
+      firewall:
+        ports:
+          - 8080:tcp
         services:
           enabled:
-            - firewalld
-            - httpd
-            - mariadb
-
-  # RHEL 9.latest ARM 64 image that is shared with an AWS project
-  - name: rhel-9-aarch64-ib
-    upload_type: aws
-    upload_options:
-      share_with_sources:
-        - "123456"
-    compose:
-      architecture: aarch64
-      distribution: rhel-9
-      image_description: RHEL 9.latest aarch64 image shared with an AWS account
-      image_type: aws
-      customizations:
-        filesystems:
-          - mountpoint: /
-            min_size: 10240
-          - mountpoint: /tmp
-            min_size: 1024
-        packages:
-            - jq
-            - sysstat
+            - ssh
+            - http
+            - https
+      groups:
+        - name: dbas
+          gid: 1002
+      services:
+        enabled:
+          - firewalld
+          - httpd
+          - mariadb

--- a/roles/image_builder/defaults/main.yaml
+++ b/roles/image_builder/defaults/main.yaml
@@ -3,11 +3,15 @@
 # by the user in group_vars.
 images: []
 
-# Endpoint required to request offline token
-sso_endpoint: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-
-# Endpoint required to interact with image builer
-api_endpoint: https://console.redhat.com/api/image-builder/v1
+# Default image request is an x86_64 image with qcow2 format and uploaded to
+# aws s3, so that it can be downloaded. Image definitions can override all or
+# part of this structure. See examples.
+default_image_request:
+  architecture: x86_64
+  image_type: guest-image
+  upload_request:
+    options: {}
+    type: aws.s3
 
 # Where to copy the images when downloading and customizing
 storage_dir: .
@@ -20,14 +24,3 @@ compose_check_wait_secs: 60
 
 # How many loops of `compose_check_retries` to do, while renewing token in between loops (if expired)
 compose_check_max_loops: 5
-
-# Map image types to file extensions
-image_type_to_extension:
-  guest-image: qcow2
-  edge-commit: tar
-  rhel-edge-commit: tar
-  edge-installer: iso
-  rhel-edge-installer: iso
-  image-installer: iso
-  vsphere: vmdk
-  vsphere-ova: ova

--- a/roles/image_builder/tasks/check-images-exist.yaml
+++ b/roles/image_builder/tasks/check-images-exist.yaml
@@ -11,8 +11,10 @@
   loop_control:
     label: "{{ path }}"
   vars:
+    requests: "{{ item.requests | default({}) }}"
     file_name: "{{ item.name }}{{ release_str | default('') }}"
-    file_extension: "{{ image_type_to_extension[item.compose.image_type] | default(item.compose.image_type) }}"
+    image_requests: "{{ default_image_request | ansible.builtin.combine(requests, recursive=true) }}"
+    file_extension: "{{ image_type_to_extension[image_requests.image_type] | default(item.requests.image_type) }}"
     path: "{{ storage_dir }}/{{ file_name }}.{{ file_extension }}"
   register: filecheck
 

--- a/roles/image_builder/tasks/download-images.yaml
+++ b/roles/image_builder/tasks/download-images.yaml
@@ -16,8 +16,9 @@
     - item.json is defined
     - item.json.image_status.status == "success"
     - item.json.image_status.upload_status.status == "success"
+    - image_url
   vars:
-    image_url: "{{ item.json.image_status.upload_status.options.url }}"
+    image_url: "{{ item.json.image_status.upload_status.options.url | default(False) }}"
     requested_type: "{{ item.json.request.image_requests[0].image_type }}"
     file_name: "{{ item.json.request.image_name }}{{ release_str | default('') }}"
     file_extension: "{{ image_type_to_extension[requested_type] | default(requested_type) }}"

--- a/roles/image_builder/tasks/request-image-creation.yaml
+++ b/roles/image_builder/tasks/request-image-creation.yaml
@@ -7,16 +7,10 @@
       Authorization: Bearer {{ refresh_token.json.access_token }}
     body:
       image_name: "{{ image.name }}"
-      image_description: "{{ image.compose.image_description | default(omit) }}"
-      distribution: "{{ image.compose.distribution }}"
-      customizations: "{{ image.compose.customizations | default(omit) }}"
-      image_requests:
-        - architecture: "{{ image.compose.architecture | default('x86_64') }}"
-          image_type: "{{ image.compose.image_type | default('guest-image') }}"
-          size: "{{ image.compose.size | default(omit) }}"
-          upload_request:
-            type: "{{ image.upload_type | default('aws.s3') }}"
-            options: "{{ image.upload_options | default('{}') }}"
+      image_description: "{{ image.description | default(omit) }}"
+      distribution: "{{ image.distribution }}"
+      customizations: "{{ image.customizations | default(omit) }}"
+      image_requests: "[ {{ default_image_request | ansible.builtin.combine(requests, recursive=true) }} ]"
     body_format: json
     status_code: 201
   register: compose_request
@@ -25,4 +19,5 @@
     label: "{{ image.name }}"
   vars:
     image: "{{ item.item }}"
+    requests: "{{ image.requests | default({}) }}"
   when: not item.stat.exists

--- a/roles/image_builder/vars/main.yaml
+++ b/roles/image_builder/vars/main.yaml
@@ -1,0 +1,16 @@
+# Endpoint required to request offline token
+sso_endpoint: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+# Endpoint required to interact with image builer
+api_endpoint: https://console.redhat.com/api/image-builder/v1
+
+# Map image types to file extensions
+image_type_to_extension:
+  guest-image: qcow2
+  edge-commit: tar
+  rhel-edge-commit: tar
+  edge-installer: iso
+  rhel-edge-installer: iso
+  image-installer: iso
+  vsphere: vmdk
+  vsphere-ova: ova


### PR DESCRIPTION
Image definitions now match the API specification.

Additionally:
- No longer need to enable `[defaults]/jinja2_native` in order to pass image size
- Will not try to download images that are not actually of a downloadable type, such as those shared to cloud providers
- Extensions on downloaded files will be set according to image_type (eg: guest-image type has qcow2 extension, vmware type has vmdk extension and so on)
- Image request will have x86_64 architecture and guest-image type by default, but can be overridden per image when explicitly defined