### PR TITLE
Less details about existing images

### DIFF
--- a/roles/image_builder/tasks/check-images-exist.yaml
+++ b/roles/image_builder/tasks/check-images-exist.yaml
@@ -23,4 +23,4 @@
   loop_control:
     label: "{{ item.invocation.module_args.path }}"
   ansible.builtin.debug:
-    msg: "{{ item.stat }}"
+    msg: "File exists: {{ item.stat.exists }}"


### PR DESCRIPTION
Do not print all of the details of existing images. It's just too much and is not used at all. Only need to show if the image exists or not.