### PR TITLE
Extend offline customizations

### DIFF
--- a/examples/main.yaml
+++ b/examples/main.yaml
@@ -151,3 +151,28 @@ images:
           - firewalld
           - httpd
           - mariadb
+
+  # An image with both online (image builder) and offline (virt-customize, virt-edit)
+  # customizations. Offline customization requires guestfs-tools package to be installed.
+  - name: rhel9-hetzner-ocp4
+    distribution: rhel-9
+    description: RHEL 9.latest image customized for OCP4 on Hetzner
+    customizations:
+      kernel:
+        append: rd.auto
+      partitioning_mode: lvm
+      packages:
+        - lvm2
+        - mdadm
+        - bzip2
+      filesystem:
+        - mountpoint: /boot
+          min_size: 1024
+        - mountpoint: /
+          min_size: 10240
+    offline_customization:
+      virt_customize:
+        - "--link /usr/bin/dracut:/sbin/dracut"
+      virt_edit:
+        - file: /etc/lvm/lvm.conf
+          expression: "s/# use_devicesfile = 1/use_devicesfile = 0/"

--- a/roles/image_builder/tasks/customize-images.yaml
+++ b/roles/image_builder/tasks/customize-images.yaml
@@ -1,28 +1,26 @@
 ---
-- name: Run virt-customize
-  ansible.builtin.shell: >
-    virt-customize -a {{ item.invocation.module_args.path }}
-    --run-command '{{ item.item.offline_customization }}'
+- name: Run virt-customize command
+  ansible.builtin.shell:
+    virt-customize -a {{ image_path }} {{ customizations }}
   loop: "{{ filecheck.results }}"
   loop_control:
-    label: "{{ item.invocation.module_args.path }}"
-  async: 1200
-  poll: 0
-  register: customize
+    label: "{{ image_path }}"
   environment:
     LIBGUESTFS_BACKEND: direct
   when:
-    - item.stat.exists
-    - item.item.offline_customization is defined | default(false)
+    - item.item.offline_customization.virt_customize is defined | default(false)
+  vars:
+    image_path: "{{ item.invocation.module_args.path }}"
+    customizations: "{{ item.item.offline_customization.virt_customize | join(' ') }}"
 
-- name: Confirm image customization finished
-  ansible.builtin.async_status:
-    jid: "{{ item.ansible_job_id }}"
-  register: job_result
-  until: job_result.finished
-  retries: 30
-  delay: 60
-  loop: "{{ customize.results }}"
+# virt-edit can only edit one single file per run, so have to do a nested loop
+- name: Run virt-edit commands
+  ansible.builtin.include_tasks: virt-edit.yaml
+  loop: "{{ filecheck.results }}"
   loop_control:
-    label: "{{ item.item.invocation.module_args.path }}"
-  when: item.changed
+    label: "{{ image_path }}"
+  when:
+    - item.item.offline_customization.virt_edit is defined | default(false)
+  vars:
+    image_path: "{{ item.invocation.module_args.path }}"
+    customizations: "{{ item.item.offline_customization.virt_edit }}"

--- a/roles/image_builder/tasks/virt-edit.yaml
+++ b/roles/image_builder/tasks/virt-edit.yaml
@@ -1,0 +1,10 @@
+---
+- name: Run virt-edit command
+  ansible.builtin.shell:
+    virt-edit -e {{ virtedit.expression | quote }} -a {{ image_path }} {{ virtedit.file }}
+  loop: "{{ customizations }}"
+  loop_control:
+    loop_var: virtedit
+    label: "{{ virtedit.file }}"
+  environment:
+    LIBGUESTFS_BACKEND: direct


### PR DESCRIPTION
Offline customizations are not the best, but sometimes they are unavoidable. There's only so much that the Image Builder API can do. For example, creating a symlink, removing packages, editing the content of a file or creating a file outside of /etc cannot be done using the API.

This MR extends offline customizations so that multiple different commands can be passed to `virt-customize` or virt-edit`, which greatly extends customization options.